### PR TITLE
Zetta Twilio driver needs accountSid & authToken to send sms...

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -1,0 +1,12 @@
+#Zetta driver for Twilio Usage Example
+
+Send text messages from Zetta.
+
+Usage : Initiate your node app after setting Twilio Account SID & Auth token via environment variables.
+
+Example :
+
+$ export TWILIO_ACCOUNT_SID=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+$ export TWILIO_AUTH_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+Run your application  

--- a/sample/server.js
+++ b/sample/server.js
@@ -7,8 +7,8 @@ var app = require('./app');
 
 var twilioOpts = {
   phoneNumber:'+XXXXXXXXXX',
-  accountSid:'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-  authToken:'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  accountSid: process.env.TWILIO_ACCOUNT_SID,
+  authToken: process.env.TWILIO_AUTH_TOKEN,
 };
 
 

--- a/sample/server.js
+++ b/sample/server.js
@@ -3,8 +3,12 @@ var Twilio = require('../');
 var SonosDriver = require('zetta-sonos-driver');
 var app = require('./app');
 
+/* Get phoneNumber, accountSid & authToken from your account in twilio */
+
 var twilioOpts = {
-  phoneNumber:'+17342452497'
+  phoneNumber:'+XXXXXXXXXX',
+  accountSid:'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  authToken:'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
 };
 
 
@@ -14,4 +18,3 @@ zetta()
   .use(SonosDriver)
   .use(app)
   .listen(1337);
-

--- a/twilio_driver.js
+++ b/twilio_driver.js
@@ -4,7 +4,7 @@ var twilio = require('twilio');
 
 var TwilioDriver = module.exports = function(opts) {
   Device.call(this);
-  this._twilio = twilio();
+  this._twilio = twilio(opts.accountSid, opts.authToken);
   this.phoneNumber = opts.phoneNumber;
 };
 util.inherits(TwilioDriver, Device);

--- a/twilio_driver.js
+++ b/twilio_driver.js
@@ -4,7 +4,7 @@ var twilio = require('twilio');
 
 var TwilioDriver = module.exports = function(opts) {
   Device.call(this);
-  this._twilio = twilio(opts.accountSid, opts.authToken);
+  this._twilio = twilio(opts.accountSid, opts.authToken, opts);
   this.phoneNumber = opts.phoneNumber;
 };
 util.inherits(TwilioDriver, Device);


### PR DESCRIPTION
Twilio driver fails to send sms since it needs account SID and Auth Token. 

/zetta-twilio-example/node_modules/zetta-twilio-driver/node_modules/twilio/lib/Client.js:20
       throw 'Client requires an Account SID and Auth Token set explicitly ' +
                                                                             ^
Client requires an Account SID and Auth Token set explicitly or via the TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN environment variables

Updated driver and samples to fix the issue.
